### PR TITLE
Adds a Lovense `GetBatch` command which appears to return a YYMMDD production batch date.

### DIFF
--- a/stpihkal/hardware/lovense.md
+++ b/stpihkal/hardware/lovense.md
@@ -479,6 +479,23 @@ _Return Example_
 OK;
 ```
 
+#### Get Production Batch Number
+
+Returns the production batch number for this device.
+This digits appear to correspond to a `YYMMDD` date during manufacture.
+
+_Availability:_ All toys? Confirmed: Lush 2, Hush, Domi.
+
+_Command Format_
+```
+GetBatch;
+```
+
+_Return Example_
+```
+190124;
+```
+
 ## Related Projects and Links
 
 The applications and repositories below contain implementations of the


### PR DESCRIPTION
Adds a Lovense `GetBatch` command which appears to return a YYMMDD production batch date.

Tested on a Lush 2 (batch 190726), a Domi (batch 190124), and a Hush (batch 160507).

 Command name found by looking through strings in the Lovense Remote desktop application.
